### PR TITLE
Change CSS to offset anchor scroll depth

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -115,3 +115,8 @@ blockquote {
   border-left: none !important;
   border-right: none !important;
 }
+
+:target:before {
+  height: 105px !important;
+  margin: -105px 0 0 !important;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding margin to offset scroll depth when clicking TOC anchor links. The additional margin is necessary in order to account for the height of the new docbar component.

## Motivation and Context

The docbar component hides the anchor/header link.

## How Has This Been Tested?

Tested locally and with Netlify build preview.

## Types of changes

CSS changes.