### PR TITLE
Changing pandevice (deprecated) to pan-os-python

### DIFF
--- a/docs/apis.md
+++ b/docs/apis.md
@@ -29,7 +29,7 @@ The new PAN-OS REST API simplifies access to policy resources on the firewall as
 
 Jumpstart your automation project with SDKs for Python and Go!
 
-##### PAN Device Framework
+##### PAN-OS-Python Framework
 
 Object-based interaction with the firewall in these language simplifies interaction with the firewall so you can focus on the automation itself. [Get Started](/docs/apis/pandevice_qs)
 

--- a/docs/apis/pandevice_qs.md
+++ b/docs/apis/pandevice_qs.md
@@ -1,4 +1,5 @@
 ---
+id: pandevice_qs
 id: pan-os-python_qs
 title: PAN-OS-Python Framework Quickstart
 sidebar_label: Quickstart

--- a/docs/apis/pandevice_qs.md
+++ b/docs/apis/pandevice_qs.md
@@ -1,44 +1,45 @@
 ---
-id: pandevice_qs
-title: PAN Device Framework Quickstart
+id: pan-os-python_qs
+title: PAN-OS-Python Framework Quickstart
 sidebar_label: Quickstart
 hide_title: false
-description: Getting started with pandevice
+description: Getting started with pan-os-python
 keywords:
   - pan-os
   - panos
   - xml
   - api
   - quickstart
-  - pandevice
+  - pan-os-python
   - sdk
   - python
+  - pandevice
 image: /img/panos_apis.svg
 ---
 
-[![GitHub page](https://img.shields.io/badge/GitHub-Repo-brightgreen?style=for-the-badge&logo=github)](https://github.com/PaloAltoNetworks/pandevice) [![GitHub stars](https://img.shields.io/github/stars/PaloAltoNetworks/pandevice?style=for-the-badge)](https://github.com/PaloAltoNetworks/pandevice)
+[![GitHub page](https://img.shields.io/badge/GitHub-Repo-brightgreen?style=for-the-badge&logo=github)](https://github.com/PaloAltoNetworks/pan-os-python) [![GitHub stars](https://img.shields.io/github/stars/PaloAltoNetworks/pan-os-python?style=for-the-badge)](https://github.com/PaloAltoNetworks/pan-os-python)
 
 ## Installation
 
-The easiest method to install pandevice is using pip:
+The easiest method to install pan-os-python is using pip (pan-os-python only supports Python3):
 
 ```
-pip install pandevice
+pip install pan-os-python
 ```
 
 Or, if you have virtualenvwrapper installed:
 
 ```shell-session
-mkvirtualenv pandevice
-pip install pandevice
+mkvirtualenv pan-os-python
+pip install pan-os-python
 ```
 
-Pip will install the [pan-python](/docs/panpython_qs) library as a dependency.
+Pip will install the [pan-python](/docs/apis/panpython_qs) library as a dependency.
 
 Upgrade to the latest version:
 
 ```shell-session
-pip install --upgrade pandevice
+pip install --upgrade pan-os-python
 ```
 
 ## How to import
@@ -46,30 +47,30 @@ pip install --upgrade pandevice
 To use Palo Alto Networks Device Framework in a project:
 
 ```python
-import pandevice
+import panos
 ```
 
 You can also be more specific about which modules you want to import:
 
 ```python
-from pandevice import firewall
-from pandevice import network
+from panos import firewall
+from panos import network
 ```
 
-## A few examples
+### A few examples
 
 For configuration tasks, create a tree structure using the classes in
 each module. Nodes hierarchy must follow the model in the [Configuration
-Tree](http://pandevice.readthedocs.io/en/latest/configtree.html).
+Tree](https://pan-os-python.readthedocs.io/en/latest/configtree.html).
 
 The following examples assume the modules were imported as such:
 
 ```python
-from pandevice import firewall
-from pandevice import network
+from panos import firewall
+from panos import network
 ```
 
-## Create a subinterface and commit:
+### Create a subinterface and commit:
 
 ```python
 fw = firewall.Firewall("10.0.0.1", api_username="admin", api_password="admin")
@@ -79,7 +80,7 @@ subeth.create()
 fw.commit()
 ```
 
-## Perform `show system info`
+### Perform `show system info`
 
 ```python
 fw = firewall.Firewall("10.0.0.1", api_username="admin", api_password="admin")
@@ -95,8 +96,46 @@ fw.refresh_system_info()
 ```
 
 :::tip
-See more examples in the [Usage Guide](http://pandevice.readthedocs.io/en/latest/usage.html).
+See more examples in the [How to Guides](https://pan-os-python.readthedocs.io/en/latest/howto.html).
 :::
+
+## Upgrade from pandevice
+
+This pan-os-python package is the evolution of the older pandevice package. To upgrade from pandevice to pan-os-python, follow these steps.
+
+### Step 1. Ensure you are using python3
+
+[Python2 is end-of-life](https://www.python.org/doc/sunset-python-2/) and not supported by pan-os-python.
+
+### Step 2. Uninstall pandevice
+
+```shell-session
+pip uninstall pandevice
+```
+
+### Step 3. Install pan-os-python
+
+```shell-session
+pip3 install pan-os-python
+```
+
+### Step 4. Change the import statements in your code from pandevice to panos
+
+```shell-session
+import pandevice
+from pandevice.firewall import Firewall
+```
+would change to
+
+```shell-session
+import panos
+from panos.firewall import Firewall
+```
+
+### Step 5. Test your script or application
+
+There are no known breaking changes between pandevice v0.14.0 and pan-os-python v1.0.0, but it is a major upgrade so please verify everything works as expected.
+
 
 ## Connecting to PAN-OS 8.0 and higher
 

--- a/docs/apis/pandevice_qs.md
+++ b/docs/apis/pandevice_qs.md
@@ -1,6 +1,5 @@
 ---
 id: pandevice_qs
-id: pan-os-python_qs
 title: PAN-OS-Python Framework Quickstart
 sidebar_label: Quickstart
 hide_title: false

--- a/docs/apis/panos_tutorials_rulebase_to_csv.mdx
+++ b/docs/apis/panos_tutorials_rulebase_to_csv.mdx
@@ -24,7 +24,7 @@ To follow this tutorial, it is recommended that that you are familiar with the c
 
 Make sure you have a Palo Alto Networks Next-Generation Firewall deployed and that you have administrative access to its Management interface via HTTPS. To avoid potential disruptions, it's recommended to run all the tests on a **non-production** environment.
 
-We will use Go in this tutorial, but the same concepts can be reused in Python using [PAN Device](pandevice_qs) or [pan-python](panpython_qs).
+We will use Go in this tutorial, but the same concepts can be reused in Python using [PAN-OS-Python](pandevice_qs) or [pan-python](panpython_qs).
 
 ## Our tool: pan-export
 

--- a/docs/automation/ansible_qs.md
+++ b/docs/automation/ansible_qs.md
@@ -24,16 +24,18 @@ API calls that are wrapped within the Ansible framework.
 ## Installation
 
 The recommended way to install the modules is installing the Palo Alto
-Networks Ansible Galaxy role:
+Networks Ansible Galaxy collection:
 
 ```shell-session
-ansible-galaxy install PaloAltoNetworks.paloaltonetworks
+ansible-galaxy collection install paloaltonetworks.panos
 ```
 
-Older modules modules are part of the default Ansible distribution
-which is available at:
+Then in your playbooks you can specify that you want to use the panos collection like so:
 
-> <https://github.com/ansible/ansible/tree/devel/lib/ansible/modules/network/panos>
+```shell-session
+collections:
+    - paloaltonetworks.panos
+```
 
 It is also available as free **Apache 2.0** licensed code from Palo Alto
 Networks Github repo if you want to see what is coming in the next release:
@@ -51,7 +53,7 @@ More comprehensive playbooks can be found under:
 
     /ansible-playbooks/
 
-## Ansible galaxy role
+## Ansible galaxy collection
 
 The Palo Alto Networks Ansible modules project is a collection of Ansible modules to automate configuration and
 operational tasks on Palo Alto Networks _Next Generation Firewalls_. The underlying protocol uses API calls that are wrapped within Ansible framework.

--- a/docs/automation/automation_tutorials_ansible_srule.mdx
+++ b/docs/automation/automation_tutorials_ansible_srule.mdx
@@ -61,12 +61,12 @@ You can easily add Ansible to any Python environment using `pip`:
 pip install ansible
 ```
 
-### Install Ansible role for PAN-OS API
+### Install Ansible collection for PAN-OS API
 
-Palo Alto Networks provides an Ansible role to facilitate working with PAN-OS API. Use `ansible-galaxy` to install it:
+Palo Alto Networks provides an Ansible collection to facilitate working with PAN-OS API. Use `ansible-galaxy` to install it:
 
 ```shell
-ansible-galaxy install PaloAltoNetworks.paloaltonetworks
+ansible-galaxy collection install paloaltonetworks.panos
 ```
 
 ### Add your environment variables
@@ -111,8 +111,8 @@ We can use the following playbook to add a new rule to the Security Rulebase of 
 - hosts: localhost
   connection: local
   
-  roles:
-    - role: PaloAltoNetworks.paloaltonetworks
+collections:
+    - paloaltonetworks.panos
 
   handlers:
     - name: commit config
@@ -159,13 +159,13 @@ PLAY [localhost] ***************************************************************
 TASK [Gathering Facts] *****************************************************************
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install pan-python required library] *********
+TASK [paloaltonetworks.panos : Install pan-python required library] *********
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install pandevice required library] **********
+TASK [paloaltonetworks.panos : Install pandevice required library] **********
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install xmltodict required library] **********
+TASK [paloaltonetworks.panos : Install xmltodict required library] **********
 ok: [127.0.0.1]
 
 TASK [include variables (free-form)] ***************************************************
@@ -198,8 +198,8 @@ The playbook we have just created also commits the configuration on Panorama whe
 - hosts: localhost
   connection: local
   
-  roles:
-    - role: PaloAltoNetworks.paloaltonetworks
+  collections:
+    - paloaltonetworks.panos
 
   handlers:
     - name: commit config
@@ -248,13 +248,13 @@ PLAY [localhost] ***************************************************************
 TASK [Gathering Facts] *****************************************************************
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install pan-python required library] *********
+TASK [paloaltonetworks.panos : Install pan-python required library] *********
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install pandevice required library] **********
+TASK [paloaltonetworks.panos : Install pandevice required library] **********
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install xmltodict required library] **********
+TASK [paloaltonetworks.panos : Install xmltodict required library] **********
 ok: [127.0.0.1]
 
 TASK [include variables (free-form)] ***************************************************
@@ -282,8 +282,8 @@ The structure of the playbook is the same with an handler performing a commit on
 - hosts: localhost
   connection: local
   
-  roles:
-    - role: PaloAltoNetworks.paloaltonetworks
+  collections:
+    - paloaltonetworks.panos
 
   handlers:
     - name: commit config
@@ -359,13 +359,13 @@ PLAY [localhost] ***************************************************************
 TASK [Gathering Facts] *****************************************************************
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install pan-python required library] *********
+TASK [paloaltonetworks.panos : Install pan-python required library] *********
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install pandevice required library] **********
+TASK [paloaltonetworks.panos : Install pandevice required library] **********
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install xmltodict required library] **********
+TASK [paloaltonetworks.panos : Install xmltodict required library] **********
 ok: [127.0.0.1]
 
 TASK [include variables (free-form)] ***************************************************
@@ -401,13 +401,13 @@ PLAY [localhost] ***************************************************************
 TASK [Gathering Facts] *****************************************************************
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install pan-python required library] *********
+TASK [paloaltonetworks.panos : Install pan-python required library] *********
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install pandevice required library] **********
+TASK [paloaltonetworks.panos : Install pandevice required library] **********
 ok: [127.0.0.1]
 
-TASK [PaloAltoNetworks.paloaltonetworks : Install xmltodict required library] **********
+TASK [paloaltonetworks.panos : Install xmltodict required library] **********
 ok: [127.0.0.1]
 
 TASK [include variables (free-form)] ***************************************************


### PR DESCRIPTION
Changing pandevice (deprecated) to pan-os-python & Upgrading ansible role (deprecated) to ansible collection

## Description

Changing pandevice to pan-os-python, changing ansible galaxy role paloaltonetworks.paloaltonetworks the new galaxy collection paloaltonetworks.panos.
The pandevice_qs could be renammed to panospython_qs.

## Motivation and Context

New framework available. Old ones are deprecated.

## How Has This Been Tested?

Documentation only, see links referring to the official projects documentation.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Documentation

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate. - No test to be added
- [ ] All new and existing tests passed. - No tests done on my mac.
