### PR TITLE
fixed password typo in creating_credential.mdx

### DIFF
--- a/docs/expedition/creating_credentials.mdx
+++ b/docs/expedition/creating_credentials.mdx
@@ -98,7 +98,7 @@ print('LOGIN')
 
 ip="127.0.0.1" #your Expedition IP reachable from the Script execution machine
 user="admin"
-passsword="paloalto"
+password="paloalto"
 
 url = 'https://'+ip+'/api/v1/login'
 credentials = {"username":user, "password":password}


### PR DESCRIPTION
## Description
Fixed typo "passsword" to "password" in the python code snippet of creating_credentials.MD file. 

## Motivation and Context

Typoe

## How Has This Been Tested?

Tested it loally

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes if appropriate.
- [x ] All new and existing tests passed.
